### PR TITLE
Add missing fields for Library that were added in a later version of Cabal

### DIFF
--- a/src/Bnfc-cabal.hs
+++ b/src/Bnfc-cabal.hs
@@ -107,6 +107,9 @@ updatePd config lang p = p
   , library = 
     Just Library 
       { exposedModules = exposedMods lang
+      , reexportedModules = []
+      , requiredSignatures = []
+      , exposedSignatures = []
       , libExposed = True
       , libBuildInfo = emptyBuildInfo 
           { buildable    = True


### PR DESCRIPTION
I was getting an error in lines 108-115 about missing fields. I added them although as empty lists. Please, check it and suggest any necessary change.
